### PR TITLE
Add elao_nginx_timeout function in .zshrc

### DIFF
--- a/README.app.md
+++ b/README.app.md
@@ -33,6 +33,10 @@ Build assets
 Enable/Disable php xdebug
 
     ⇒ elao_php_xdebug [on|off]
+    
+Enable/Disable nginx long timeout (999s instead of default 60s)
+    
+    ⇒ elao_nginx_timeout [on|off]
 
 Run test
 

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -85,6 +85,12 @@ elao_ohmyzsh_users:
   - user:     "{{ _user }}"
     template: users/{{ _env }}.j2
     config:
+      - |
+        elao_nginx_timeout () {
+            if [[ $1 == off ]]; then sudo sed -ri 's/fastcgi_read_timeout (.*);$/fastcgi_read_timeout 999s;#origin\1/' /etc/nginx/conf.d/php_fpm_params
+            else sudo sed -ri 's/^fastcgi_read_timeout 999s;#origin(.*)/fastcgi_read_timeout \1;/' /etc/nginx/conf.d/php_fpm_params; fi
+            sudo /etc/init.d/nginx restart
+        }
       - ZSH_THEME: elao-dev
       - plugins: (git debian common-aliases history history-substring-search npm composer symfony2)
       - export PATH: ./bin:$PATH


### PR DESCRIPTION
Add function elao_nginx_timeout(long | short) in zshrc to avoid 504 (Gateway timeout) when debugging.

Timeout can't be simply disabled in nginx, so ` ⇒ elao_nginx_timeout long` will set timeout to 900s (15 minutes) instead of the default 60s.