### PR TITLE
Conform to upstream: [Monolog] Console handler don't bubble anymore

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,7 +20,6 @@ monolog:
             channels: [!event]
         console:
             type:   console
-            bubble: false
             channels: ["!event", "!doctrine"]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration


### PR DESCRIPTION
Do not let the console handler eat all the logs (handlers defined after wouldn't get anything otherwise)

See https://github.com/lyrixx/symfony-standard/commit/8fb1e8173e9c7b9c327dad2c0abada0b1809f9d2

Originally, this commit has been merged in 2.7. But actually, I saw the 2.7 is not up-to-date with upstream. So I assumed you won't maintain the 2.7 branch ?