### PR TITLE
Fix typehint causing deprecation notice in composer hook

### DIFF
--- a/app/SymfonyStandard/Composer.php
+++ b/app/SymfonyStandard/Composer.php
@@ -11,11 +11,11 @@
 
 namespace SymfonyStandard;
 
-use Composer\Script\CommandEvent;
+use Composer\Script\Event;
 
 class Composer
 {
-    public static function hookCreateProject(CommandEvent $event)
+    public static function hookCreateProject(Event $event)
     {
         $files = [
             'Vagrantfile',


### PR DESCRIPTION
This fixes the deprecation notice triggered by composer during the post-create-project-cmd event:

> Deprecation Notice: The callback SymfonyStandard\Composer::hookCreateProject declared at elao-standard/app/SymfonyStandard/Composer.php accepts a Composer\Script\CommandEvent but post-create-project-cmd events use a Composer\Script\Event instance. Please adjust your type hint accordingly, see https://getcomposer.org/doc/articles/scripts.md#event-classes in phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php:289

As far as I know, that's documented by the [class itself](https://github.com/composer/composer/blob/master/src/Composer/Script/CommandEvent.php#L18) but nor in the link provided by the notice, neither in the other documentation chapters.
